### PR TITLE
fixed product description showing up instead of name in two locations

### DIFF
--- a/app/Http/Controllers/Admin/ServerController.php
+++ b/app/Http/Controllers/Admin/ServerController.php
@@ -228,7 +228,7 @@ class ServerController extends Controller
                 return '<a href="' . route('admin.users.show', $server->user->id) . '">' . $server->user->name . '</a>';
             })
             ->addColumn('resources', function (Server $server) {
-                return $server->product->description;
+                return $server->product->name;
             })
             ->addColumn('actions', function (Server $server) {
                 $suspendColor = $server->isSuspended() ? 'btn-success' : 'btn-warning';


### PR DESCRIPTION
This seems to be referenced two places, admin/servers and admin/users/1

I could not find any other effects of this change but do feel free to double check my work.

themes/default/views/admin/servers/table.blade.php
And
themes/default/views/admin/users/show.blade.php
and perhaps
themes/default/views/admin/users/edit.blade.php

have 
`data: 'resources',
 name: 'product.name',`
                    
In them, another fix would be to alter this to `data: 'product.name'` but the proposed change seems like the right one.